### PR TITLE
example to illustrate that the network is awaiting approval from the NAP

### DIFF
--- a/json-examples/svc/bgp-conf-peering-awaiting-validation.json
+++ b/json-examples/svc/bgp-conf-peering-awaiting-validation.json
@@ -1,0 +1,43 @@
+{
+  "ietf-ac-svc:attachment-circuits": {
+    "ac": [
+      {
+        "name": "IPT-NET-ABC",
+        "role": "ietf-ac-common:public-nni",
+        "routing-protocols": {
+          "routing-protocol": [
+            {
+              "id": "BGP",
+              "type": "ietf-vpn-common:bgp-routing",
+              "bgp": {
+                "neighbor": [
+                  {
+                    "id": "NAP-1",
+                    "server-reference": "peering-svc-45857",
+                    "local-address": "198.51.100.1",
+                    "remote-address": "100.100.100.1",
+                    "local-as": 65536,
+                    "peer-as": 65537,
+                    "address-family": "ietf-vpn-common:ipv4",
+                    "authentication": {
+                      "enabled": true,
+                      "keying-material": {
+                        "key-id": 1,
+                        "key": "test##"
+                      }
+                    },
+                    "status": {
+                      "admin-status": {
+                        "status": "ietf-ac-common:awaiting-validation"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
+ return server generated reference for this BGP session